### PR TITLE
Add flags to the operator init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can install `operator` using `brew` and [the operatorai tap](https://github.
 
 ## Usage
 
-Set up the CLI tool using `operator init`. It will take you through a one-off set up:
+Optionally, set up the CLI tool using `operator init`. It will take you through a one-off set up, and store your preferences.
 
 ```bash
 ❯ operator init
@@ -39,7 +39,7 @@ Use the arrow keys to navigate: ↓ ↑ → ←
     Google Cloud Run
 ```
 
-Create a new deployment with `operator create`:
+Create a new deployment with `operator create` (check out `operator create --help` for a full list of options).
 
 ```bash
 ❯ operator create service.hello-world
@@ -53,11 +53,13 @@ To get started, use the `make install` command which will create a `pyenv` virtu
 ❯ cd service.hello-world
 ❯ make install # To create a pyenv-virtualenv
 ```
+
 Launch it locally:
 
 ```bash
 ❯ make localhost
 ```
+
 ... and, when you're ready, deploy it!
 
 ```bash

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -41,8 +41,8 @@ func init() {
 
 	// Set up the config for this template
 	configValues = &config.TemplateConfig{}
-	createCmd.Flags().StringVar(&configValues.Runtime, "runtime", viper.GetString(config.Runtime), "The function's runtime language")
 	createCmd.Flags().StringVar(&configValues.Type, "type", viper.GetString(config.DeploymentType), "The type of deployment to create")
+	createCmd.Flags().StringVar(&configValues.Runtime, "runtime", viper.GetString(config.Runtime), "The function's runtime language")
 	createCmd.Flags().StringVar(&configValues.DeploymentRegion, "region", viper.GetString(config.DeploymentRegion), "The region to deploy to")
 
 	// Google Cloud specific flags

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,78 +26,113 @@ The init command allows you to set up your preferences.`,
 	Run: runInit,
 }
 
+var initValues *config.TemplateConfig
+
 func init() {
 	rootCmd.AddCommand(initCmd)
+
+	// Enable operator init to also work with flags
+	initValues = &config.TemplateConfig{}
+	initCmd.Flags().StringVar(&initValues.Type, "type", "", "The type of deployment to create")
+	initCmd.Flags().StringVar(&initValues.Runtime, "runtime", "", "The function's runtime language")
+	initCmd.Flags().StringVar(&initValues.DeploymentRegion, "region", "", "The region to deploy to")
+
+	// Google Cloud specific flags
+	initCmd.Flags().StringVar(&initValues.ProjectID, "project-id", "", "The gcloud project use")
 }
 
 func runInit(cmd *cobra.Command, args []string) {
+
 	// A configChoice is defined as:
-	// 1. The label, which is shown in the prompt
-	// 2. The values (keys are shown in the prompt, values are stored in config)
-	// 3. The config key (the selection will be stored in viper using this)
 	type configChoice struct {
-		label  string
-		values map[string]string
-		key    string
-	}
+		// The label, which is shown in the prompt to the end user
+		label string
 
-	s := spinner.StartNew("Collecting Google Cloud projects and regions...")
-	cloudProjects, err := getGoogleCloudProjects()
-	if err != nil {
-		fmt.Printf("Unable to query for active projects: %v", err)
-		return
-	}
-	if len(cloudProjects) == 0 {
-		fmt.Printf("Could not find any active Google projects")
-		return
-	}
+		// The config key: the selection will be stored in viper using this
+		key string
 
-	deploymentRegions, err := getGoogleCloudRegions()
-	if err != nil {
-		fmt.Printf("Unable to query for deployment regions: %v", err)
-		return
+		// The flagValue, which has optionally been added by the user
+		flagValue string
+
+		// A function to collect values if the user does not provide one via a flag
+		collectValuesFunc func() (map[string]string, error)
+
+		// A function to validate the choice
+		validationFunc func(string) error
 	}
-	if len(deploymentRegions) == 0 {
-		fmt.Printf("Could not find any active Google projects")
-		return
-	}
-	s.Stop()
 
 	configChoices := []configChoice{
 		{
 			// Pick a Google Cloud Project
-			label:  "Google Cloud Project",
-			values: cloudProjects,
-			key:    config.ProjectID,
+			label:             "Google Cloud Project",
+			key:               config.ProjectID,
+			flagValue:         initValues.ProjectID,
+			collectValuesFunc: getGoogleCloudProjects,
+			validationFunc:    isActiveGoogleCloudProject,
 		},
 		{
 			// Pick a deployment region
-			label:  "Deployment Region",
-			values: deploymentRegions,
-			key:    config.DeploymentRegion,
+			label:             "Deployment Region",
+			key:               config.DeploymentRegion,
+			flagValue:         initValues.DeploymentRegion,
+			collectValuesFunc: getGoogleCloudRegions,
+			validationFunc:    isValidGoogleCloudRegion,
 		},
 		{
 			// Pick the default deployment type
-			label:  "Deployment type",
-			values: config.DeploymentNames,
-			key:    config.DeploymentType,
+			label:     "Deployment type",
+			key:       config.DeploymentType,
+			flagValue: initValues.Type,
+			collectValuesFunc: func() (map[string]string, error) {
+				return config.DeploymentNames, nil
+			},
+			validationFunc: func(v string) error {
+				if !config.DeploymentTypes.Contains(v) {
+					return errors.New(fmt.Sprintf("unknown type: %s (%s)", v, config.DeploymentTypes))
+				}
+				return nil
+			},
 		},
 		{
 			// Pick the default programming language
-			label:  "Programming language",
-			values: config.RuntimeNames,
-			key:    config.Runtime,
+			label:     "Programming language",
+			key:       config.Runtime,
+			flagValue: initValues.Runtime,
+			collectValuesFunc: func() (map[string]string, error) {
+				return config.RuntimeNames, nil
+			},
+			validationFunc: func(v string) error {
+				if !config.Runtimes.Contains(v) {
+					return errors.New(fmt.Sprintf("unknown runtime: %s (%s)", v, config.Runtimes))
+				}
+				return nil
+			},
 		},
 	}
 
 	// Iterate on all of the choices
 	for _, choice := range configChoices {
-		value, err := getValue(choice.label, choice.values)
-		if err != nil {
-			fmt.Printf("Unknown value: %v\n", value)
-			return
+		if choice.flagValue != "" {
+			// The user has input a value as a flag; so we validate & store it
+			if err := choice.validationFunc(choice.flagValue); err != nil {
+				fmt.Printf("Error: %v", err)
+				return
+			}
+			viper.Set(choice.key, choice.flagValue)
+		} else {
+			// The user has not input a value as a flag; we collect the
+			// available values and show them as a prompt
+			values, err := choice.collectValuesFunc()
+			if err != nil {
+				fmt.Printf("Error: %v", err)
+				return
+			}
+			value, err := getValue(choice.label, values)
+			if err != nil {
+				return
+			}
+			viper.Set(choice.key, value)
 		}
-		viper.Set(choice.key, value)
 	}
 
 	// Does not use SafeWrite - overwrites everything
@@ -121,13 +157,25 @@ func getValue(label string, values map[string]string) (string, error) {
 	return values[result], nil
 }
 
+func getString(label string, validation func(string) error) (string, error) {
+	prompt := promptui.Prompt{
+		Label:    label,
+		Validate: validation,
+	}
+	return prompt.Run()
+}
+
 func getGoogleCloudProjects() (map[string]string, error) {
-	// Construct the gcloud command
+	s := spinner.StartNew("Collecting Google Cloud projects...")
+	defer s.Stop()
+
 	// gcloud projects list --format="json"
+	projectListLimit := 25
 	commandArgs := []string{
 		"projects",
 		"list",
 		"--format=\"json\"",
+		fmt.Sprintf("--limit=%d", projectListLimit),
 	}
 
 	output, err := executeCommandWithResult("gcloud", commandArgs)
@@ -143,16 +191,55 @@ func getGoogleCloudProjects() (map[string]string, error) {
 	if err := json.Unmarshal(output, &results); err != nil {
 		return nil, err
 	}
+	if len(results) == projectListLimit {
+		// Bail if the user has too many projects to 'reasonably' display
+		return nil, errors.New(fmt.Sprintf("you have %d or more Google Cloud projects. "+
+			"Please use operator init --project-id <id> to specify a project.", projectListLimit))
+	}
 
 	projectIDs := map[string]string{}
 	for _, project := range results {
-		projectIDs[project.Name] = project.ProjectID
+		displayName := fmt.Sprintf("%s (%s)", project.Name, project.ProjectID)
+		projectIDs[displayName] = project.Name
 	}
 	return projectIDs, nil
 }
 
+func isActiveGoogleCloudProject(projectID string) error {
+	s := spinner.StartNew(fmt.Sprintf("Checking Google Cloud project: %s...", projectID))
+	defer s.Stop()
+
+	// gcloud projects describe <id> --format="json"
+	commandArgs := []string{
+		"projects",
+		"describe",
+		projectID,
+		"--format=\"json\"",
+	}
+
+	output, err := executeCommandWithResult("gcloud", commandArgs)
+	if err != nil {
+		return err
+	}
+
+	type gcloudResult struct {
+		LifecycleState string `json:"lifecycleState"`
+	}
+	var result gcloudResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		return err
+	}
+
+	if result.LifecycleState != "ACTIVE" {
+		return errors.New("Project is not currently active")
+	}
+	return nil
+}
+
 func getGoogleCloudRegions() (map[string]string, error) {
-	// Construct the gcloud command
+	s := spinner.StartNew("Collecting Google Cloud regions...")
+	defer s.Stop()
+
 	// gcloud functions regions list --format="json"
 	commandArgs := []string{
 		"functions",
@@ -181,6 +268,39 @@ func getGoogleCloudRegions() (map[string]string, error) {
 		regions[displayName] = region.LocationID
 	}
 	return regions, nil
+}
+
+func isValidGoogleCloudRegion(locationID string) error {
+	s := spinner.StartNew("Collecting Google Cloud regions...")
+	defer s.Stop()
+
+	// gcloud functions regions list --format="json"
+	commandArgs := []string{
+		"functions",
+		"regions",
+		"list",
+		"--format=\"json\"",
+	}
+
+	output, err := executeCommandWithResult("gcloud", commandArgs)
+	if err != nil {
+		return err
+	}
+
+	type gcloudResults struct {
+		LocationID string `json:"locationId"`
+	}
+	var results []gcloudResults
+	if err := json.Unmarshal(output, &results); err != nil {
+		return err
+	}
+
+	for _, region := range results {
+		if region.LocationID == locationID {
+			return nil
+		}
+	}
+	return errors.New(fmt.Sprintf("unknown region: %s", locationID))
 }
 
 func executeCommandWithResult(command string, args []string) ([]byte, error) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -110,7 +110,7 @@ func runInit(cmd *cobra.Command, args []string) {
 		},
 	}
 
-	// Iterate on all of the choices
+	// Iterate on the flags first, which are quicker to validate
 	for _, choice := range configChoices {
 		if choice.flagValue != "" {
 			// The user has input a value as a flag; so we validate & store it
@@ -119,7 +119,13 @@ func runInit(cmd *cobra.Command, args []string) {
 				return
 			}
 			viper.Set(choice.key, choice.flagValue)
-		} else {
+		}
+	}
+
+	// Iterate on all of the remaining choices second, since
+	// it is slower to collect their values
+	for _, choice := range configChoices {
+		if choice.flagValue == "" {
 			// The user has not input a value as a flag; we collect the
 			// available values and show them as a prompt
 			values, err := choice.collectValuesFunc()

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -135,7 +135,7 @@ func templatesGcloudFunctionsMakefile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/Makefile", size: 282, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/Makefile", size: 282, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -155,7 +155,7 @@ func templatesGcloudFunctionsReadmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/README.md", size: 149, mode: os.FileMode(420), modTime: time.Unix(1602941522, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/README.md", size: 149, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -175,7 +175,7 @@ func templatesGcloudFunctionsBin_configSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/bin/_config.sh", size: 75, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/bin/_config.sh", size: 75, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -195,7 +195,7 @@ func templatesGcloudFunctionsBinCleanupSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/bin/cleanup.sh", size: 245, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/bin/cleanup.sh", size: 245, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -215,7 +215,7 @@ func templatesGcloudFunctionsBinLaunchSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/bin/launch.sh", size: 347, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/bin/launch.sh", size: 347, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -235,7 +235,7 @@ func templatesGcloudFunctionsBinRemove_pyenvSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/bin/remove_pyenv.sh", size: 412, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/bin/remove_pyenv.sh", size: 412, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -255,7 +255,7 @@ func templatesGcloudFunctionsBinSetup_pyenvSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/bin/setup_pyenv.sh", size: 731, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/bin/setup_pyenv.sh", size: 731, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -275,7 +275,7 @@ func templatesGcloudFunctionsMainPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/main.py", size: 616, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/main.py", size: 616, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -295,7 +295,7 @@ func templatesGcloudFunctionsModel__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -315,7 +315,7 @@ func templatesGcloudFunctionsModelArtifactsReadmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/model/artifacts/README.md", size: 82, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/model/artifacts/README.md", size: 82, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -335,7 +335,7 @@ func templatesGcloudFunctionsModelArtifacts__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -355,7 +355,7 @@ func templatesGcloudFunctionsModelArtifactsFilesPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/model/artifacts/files.py", size: 438, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/model/artifacts/files.py", size: 438, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -375,7 +375,7 @@ func templatesGcloudFunctionsModelModelPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/model/model.py", size: 484, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/model/model.py", size: 484, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -395,7 +395,7 @@ func templatesGcloudFunctionsRequirementsDevTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/requirements-dev.txt", size: 41, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/requirements-dev.txt", size: 41, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -415,7 +415,7 @@ func templatesGcloudFunctionsRequirementsTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/requirements.txt", size: 13, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/requirements.txt", size: 13, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -435,7 +435,7 @@ func templatesGcloudFunctionsTests__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/tests/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/tests/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -455,7 +455,7 @@ func templatesGcloudFunctionsTestsModel__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -475,7 +475,7 @@ func templatesGcloudFunctionsTestsModelArtifacts__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -495,7 +495,7 @@ func templatesGcloudFunctionsTestsModelArtifactsTest_filesPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/artifacts/test_files.py", size: 270, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/artifacts/test_files.py", size: 270, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -515,7 +515,7 @@ func templatesGcloudFunctionsTestsModelTest_modelPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/test_model.py", size: 520, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/functions/tests/model/test_model.py", size: 520, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -535,7 +535,7 @@ func templatesGcloudRunDockerignore() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/.dockerignore", size: 72, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/.dockerignore", size: 72, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -555,7 +555,7 @@ func templatesGcloudRunDockerfile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/Dockerfile", size: 672, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/Dockerfile", size: 672, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -575,7 +575,7 @@ func templatesGcloudRunMakefile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/Makefile", size: 425, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/Makefile", size: 425, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -595,7 +595,7 @@ func templatesGcloudRunReadmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/README.md", size: 154, mode: os.FileMode(420), modTime: time.Unix(1602941988, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/README.md", size: 154, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -615,7 +615,7 @@ func templatesGcloudRunBin_configSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/bin/_config.sh", size: 75, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/bin/_config.sh", size: 75, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -635,7 +635,7 @@ func templatesGcloudRunBinCleanupSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/bin/cleanup.sh", size: 245, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/bin/cleanup.sh", size: 245, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -655,7 +655,7 @@ func templatesGcloudRunBinLaunchSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/bin/launch.sh", size: 314, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/bin/launch.sh", size: 314, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -675,7 +675,7 @@ func templatesGcloudRunBinRemove_pyenvSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/bin/remove_pyenv.sh", size: 412, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/bin/remove_pyenv.sh", size: 412, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -695,7 +695,7 @@ func templatesGcloudRunBinSetup_pyenvSh() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/bin/setup_pyenv.sh", size: 731, mode: os.FileMode(493), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/bin/setup_pyenv.sh", size: 731, mode: os.FileMode(493), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -715,7 +715,7 @@ func templatesGcloudRunMainPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/main.py", size: 486, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/main.py", size: 486, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -735,7 +735,7 @@ func templatesGcloudRunModel__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -755,7 +755,7 @@ func templatesGcloudRunModelArtifactsReadmeMd() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/model/artifacts/README.md", size: 82, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/model/artifacts/README.md", size: 82, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -775,7 +775,7 @@ func templatesGcloudRunModelArtifacts__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -795,7 +795,7 @@ func templatesGcloudRunModelArtifactsFilesPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/model/artifacts/files.py", size: 438, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/model/artifacts/files.py", size: 438, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -815,7 +815,7 @@ func templatesGcloudRunModelModelPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/model/model.py", size: 419, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/model/model.py", size: 419, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -835,7 +835,7 @@ func templatesGcloudRunRequirementsDevTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/requirements-dev.txt", size: 13, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/requirements-dev.txt", size: 13, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -855,7 +855,7 @@ func templatesGcloudRunRequirementsTxt() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/requirements.txt", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/requirements.txt", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -875,7 +875,7 @@ func templatesGcloudRunTests__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/tests/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/tests/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -895,7 +895,7 @@ func templatesGcloudRunTestsModel__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -915,7 +915,7 @@ func templatesGcloudRunTestsModelArtifacts__init__Py() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/artifacts/__init__.py", size: 0, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -935,7 +935,7 @@ func templatesGcloudRunTestsModelArtifactsTest_filesPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/artifacts/test_files.py", size: 270, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/artifacts/test_files.py", size: 270, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -955,7 +955,7 @@ func templatesGcloudRunTestsModelTest_modelPy() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/test_model.py", size: 520, mode: os.FileMode(420), modTime: time.Unix(1602453168, 0)}
+	info := bindataFileInfo{name: "templates/gcloud/run/tests/model/test_model.py", size: 520, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -975,7 +975,7 @@ func templatesHelpersGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/helpers.go", size: 1516, mode: os.FileMode(420), modTime: time.Unix(1602941383, 0)}
+	info := bindataFileInfo{name: "templates/helpers.go", size: 1516, mode: os.FileMode(420), modTime: time.Unix(1602942419, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Feed back from Ching-Wei: https://twitter.com/cweichen/status/1318288107880484870

> I got to step 3, and ran into the wall of "my company has hundreds of GCP projects", so some way of prefix-filtering would be useful :) In most cases people know the name of the project anyway, no?

This PR enables the `operator init` command to optionally include flags. If a flag is included, its value just gets validated and stored; if the flag is not included, `operator` falls back on collecting the values, as before. 

To deal with the special edge case of having loads of GCP projects, I've added an escape hatch whereby `operator init` will error and ask the user to specify the `--project-id` if, when listing projects, it finds 25 or more.

I have now tested this locally with an increasing number of flags:
```
❯ operator init
❯ operator init --project-id <project-id>
❯ operator init --project-id <project-id> --region <region-id>
❯ operator init --project-id <project-id> --region <region-id> --type <type> --runtime python37
❯ operator init --project-id <project-id> --region <region-id> --type <type> --runtime python37
```